### PR TITLE
fixed scikit-learn mispelling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-scikit_learn==1.0.2
+scikit-learn==1.0.2
 streamlit==1.7.0


### PR DESCRIPTION
Is the scikit-learn package mispelled? I'm using anaconda on Windows and I didn't see any scikit_learn package when creating a virtual environment, however there was a scikit-learn package. Was this package mispelled?